### PR TITLE
Don't include discord discriminator if the user has switched to the n…

### DIFF
--- a/IrcDiscordRelay.cs
+++ b/IrcDiscordRelay.cs
@@ -220,7 +220,15 @@ namespace IrcDiscordRelay
             if (discordToIrcChannelMap.TryGetValue(message.Channel.Id, out string ircChannel))
             {
                 // Determine if this message is a reply to another message
-                string author = $"<{message.Author}>";
+                // Don't include the tag if it is 0000 (user has switched to the new username system
+                string author;
+                if (message.Author.Discriminator == "0000") {
+                    author = $"<{message.Author.Username}>";
+                }
+                else
+                {
+                    author = $"<{message.Author}>";
+                }
                 if (message.Reference != null)
                 {
                     IMessage repliedToMessage = await message.Channel.GetMessageAsync(message.Reference.MessageId.Value);
@@ -236,7 +244,14 @@ namespace IrcDiscordRelay
                     }
                     else
                     {
-                        author = $"<{message.Author}, replying to {repliedToMessage.Author}>";
+                        // Don't include the tag if it is 0000 (user has switched to the new username system
+                        if (message.Author.Discriminator == "0000") {
+                            author = $"<{message.Author}, replying to {repliedToMessage.Author.Username}>";
+                        }
+                        else
+                        {
+                            author = $"<{message.Author}, replying to {repliedToMessage.Author}>";
+                        }
                     }
                 }
 


### PR DESCRIPTION
…ew username system

the new username system on discord gets rid of discriminators. When you switch to the new format, you discriminator shows on IRC as 0000, and this doesn't need to be shown. The discriminator is still shown for those who haven't switched to the new format yet.

We simply check if the discriminator is 0000 only include the discriminator if it isn't that.